### PR TITLE
Sometimes Safari spins forever

### DIFF
--- a/components/video-player.js
+++ b/components/video-player.js
@@ -33,7 +33,6 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
   const error = (event) => onError(event);
 
   const onImageLoad = (event) => {
-    console.log('debug onImageLoad'); // eslint-disable-line no-console
     const [w, h] = [event.target.width, event.target.height];
     if (w && h) {
       setIsVertical((w / h) < 1);
@@ -49,7 +48,6 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
    * which determines styles for the player
    */
   useEffect(() => {
-    console.log('debug new img'); // eslint-disable-line no-console
     const img = new Image();
     img.onload = onImageLoad;
     img.src = poster;

--- a/components/video-player.js
+++ b/components/video-player.js
@@ -1,3 +1,4 @@
+/* globals Image */
 import { useState, useEffect, useRef } from 'react';
 import Hls from 'hls.js';
 import mux from 'mux-embed';
@@ -26,7 +27,6 @@ const noop = () => {};
  */
 export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = noop }) {
   const videoRef = useRef(null);
-  const imageRef = useRef(null);
   const [isVertical, setIsVertical] = useState();
   const [playerInitTime] = useState(Date.now());
 
@@ -34,7 +34,6 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
 
   const onImageLoad = (event) => {
     console.log('debug onImageLoad'); // eslint-disable-line no-console
-    event.persist();
     const [w, h] = [event.target.width, event.target.height];
     if (w && h) {
       setIsVertical((w / h) < 1);
@@ -44,6 +43,17 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
       console.error('Error getting img dimensions', event); // eslint-disable-line no-console
     }
   };
+
+  /*
+   * See comment above -- we're loading the poster image just so we can grab the dimensions
+   * which determines styles for the player
+   */
+  useEffect(() => {
+    console.log('debug new img'); // eslint-disable-line no-console
+    const img = new Image();
+    img.onload = onImageLoad;
+    img.src = poster;
+  }, []);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -93,12 +103,7 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
   return (
     <>
       <video ref={videoRef} poster={poster} controls />
-      {/* See large comment above about what we're doing here */}
-      <img ref={imageRef} src={poster} onLoad={onImageLoad} alt="Thumbnail" />
       <style jsx>{`
-        img {
-          display: none;
-        }
         video {
           display: block;
           width: ${isVertical ? 'auto' : '1000px'};

--- a/components/video-player.js
+++ b/components/video-player.js
@@ -33,6 +33,7 @@ export default function VideoPlayer ({ playbackId, poster, onLoaded, onError = n
   const error = (event) => onError(event);
 
   const onImageLoad = (event) => {
+    console.log('debug onImageLoad'); // eslint-disable-line no-console
     event.persist();
     const [w, h] = [event.target.width, event.target.height];
     if (w && h) {


### PR DESCRIPTION
There's a bug where Safari will show a spinner forever. From the network tab I can see that the `display: none` image never gets requested, which means the image never loads, and we never get the `onImageLoaded` callback.

Solution here is to use the `new Image` constructor instead of the `display: none` image in the DOM