### PR TITLE
Specify Video Only

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,7 +48,7 @@ const Index: React.FC<Props> = () => {
               <span className="cta-text-mobile">Add a video</span>
               <span className="cta-text-desktop">Upload a video</span>
             </Button>
-            <input id="file-input" type="file" onChange={onInputChange} ref={inputRef} />
+            <input id="file-input" type="file" accept="video/*" onChange={onInputChange} ref={inputRef} />
           </label>
           <div className="cta-record">
             <Link href="/record?source=camera"><Button>Record from camera</Button></Link>


### PR DESCRIPTION
Hi, so when I used my Galaxy A51 smartphone I opened up the site and clicked add a video and one of the options was to use the camera. But when I clicked on the camera it, only let me take a photo oof. 

This PR might fix that, but honestly it's untested. So I'll go test it when I get a deploy preview. Thanks!