### PR TITLE
this decreases the max height of the video player

### DIFF
--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -137,7 +137,7 @@ const VideoPlayer: React.FC<Props> = ({ playbackId, poster, onLoaded, onError })
         }
         @media only screen and (min-width: ${breakpoints.md}px) {
           video {
-            max-height: 80vh;
+            max-height: 70vh;
           }
         }
       `}


### PR DESCRIPTION
- necessary especially on horizonatal view ipads to make sure there's room for the footer
- might be a better way to approach this, but has to be done carfully to
make sure all combinations of screen sizes and vidoe source sizes look
good, for now, this is a hotfix