### PR TITLE
Plyr by default uses local storage to remember settings, let's not

### DIFF
--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -79,6 +79,7 @@ const VideoPlayer: React.FC<Props> = ({ playbackId, poster, onLoaded, onError })
       video.addEventListener('error', videoError);
       playerRef.current = new Plyr(video, {
         previewThumbnails: { enabled: true, src: `https://image.mux.com/${playbackId}/storyboard.vtt` },
+        storage: { enabled: false }
       });
 
       if (video.canPlayType('application/vnd.apple.mpegurl')) {


### PR DESCRIPTION
Plyr will use local storage to remember things like playback rate, quality, captions, etc.

Let's not do that, we don't need to remember those things between refreshes and viewing different videos. If I watch one video at 2x speed and then at some time later come back for a different video I don't think many people would expect the 2nd video to be playing at 2x speed.