### PR TITLE
Fix vertical video controls overlap and styling

### DIFF
--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -144,6 +144,7 @@ const VideoPlayer: React.FC<Props> = ({ playbackId, poster, onLoaded, onError })
         }
         .video-container {
           margin-bottom: 40px;
+          margin-top: 40px;
           border-radius: 30px;
         }
         :global(.plyr:fullscreen video) {
@@ -159,7 +160,6 @@ const VideoPlayer: React.FC<Props> = ({ playbackId, poster, onLoaded, onError })
           max-width: 100%;
           max-height: 50vh;
           cursor: pointer;
-          margin-top: 40px;
         }
         @media only screen and (min-width: ${breakpoints.md}px) {
           video {

--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -166,6 +166,14 @@ const VideoPlayer: React.FC<Props> = ({ playbackId, poster, onLoaded, onError })
             max-height: 70vh;
           }
         }
+        @media only screen and (max-width: ${breakpoints.md}px) {
+          :global(:root) {
+            --plyr-control-icon-size: ${isVertical ? '10px' : '18px'};
+            --plyr-font-size-time: ${isVertical ? '10px' : '12px'};
+          }
+          :global(.plyr__volume, .plyr__menu, .plyr--pip-supported [data-plyr=pip]) {
+            display: none;
+          }
       `}
       </style>
     </>


### PR DESCRIPTION
Removes the volume, settings and pip controls with pure CSS selectors not the Plyr init controls key (see https://github.com/sampotts/plyr#initialising) while in a vertical and width < 756px state. Also, makes the time progress text size a bit smaller in vertical videos

<img height="500" alt="Screen Shot 2020-11-17 at 1 41 23 PM" src="https://user-images.githubusercontent.com/39253711/99432490-34474680-28da-11eb-83dd-bb0c2cbd8946.PNG">

I've also switched the `margin-top: 40px` css from `video` to `.video-container` so it removed this black empty space:

<img width="1104" alt="Screen Shot 2020-11-17 at 1 42 23 PM" src="https://user-images.githubusercontent.com/39253711/99432921-d830f200-28da-11eb-9639-0b56b819054f.png"> 


Fixes https://github.com/muxinc/stream.new/issues/43