### PR TITLE
Add a simple duration sanity check

### DIFF
--- a/components/record-page.tsx
+++ b/components/record-page.tsx
@@ -54,6 +54,7 @@ const RecordPage: React.FC<NoProps> = () => {
   const finalBlob = useRef<Blob | null>(null);
   const countdownTimerRef = useRef<CountdownTimerHandles | null>(null);
   const [deviceList, setDevices] = useState({ video: [], audio: [] } as DeviceList);
+  const [showUploadPage, setShowUploadPage] = useState(true);
 
   useEffect(() => {
     if (router.query && router.query.source) {
@@ -381,8 +382,13 @@ const RecordPage: React.FC<NoProps> = () => {
     await getDevices();
   };
 
-  if (file) {
-    return <UploadProgressFullpage file={file} />;
+  const resetPage = () => {
+    setShowUploadPage(false);
+    hardCleanup();
+  };
+
+  if (file && showUploadPage) {
+    return <UploadProgressFullpage file={file} resetPage={resetPage}/>;
   }
 
   /*

--- a/components/record-page.tsx
+++ b/components/record-page.tsx
@@ -123,6 +123,7 @@ const RecordPage: React.FC<NoProps> = () => {
     }
     setRecordState(RecordState.IDLE);
     setErrorMessage('');
+    setShowUploadPage(false);
   };
 
   /*
@@ -352,8 +353,9 @@ const RecordPage: React.FC<NoProps> = () => {
       logger.error('Cannot submit recording without a blob');
       return;
     }
-    const createdFile = new File([finalBlob.current], 'video-from-camera');
+    const createdFile = new File([finalBlob.current], 'video-from-camera', {type: finalBlob.current.type});
     setFile(createdFile);
+    setShowUploadPage(true);
   };
 
   const muteAudioTrack = (shouldMute: boolean) => {
@@ -382,13 +384,8 @@ const RecordPage: React.FC<NoProps> = () => {
     await getDevices();
   };
 
-  const resetPage = () => {
-    setShowUploadPage(false);
-    hardCleanup();
-  };
-
   if (file && showUploadPage) {
-    return <UploadProgressFullpage file={file} resetPage={resetPage}/>;
+    return <UploadProgressFullpage file={file} resetPage={hardCleanup}/>;
   }
 
   /*

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -90,7 +90,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
       video.preload = 'metadata';
       video.onloadedmetadata = function() {
         URL.revokeObjectURL(video.src);
-        if (video.duration < MAX_VIDEO_DURATION_SEC) {
+        if (video.duration > MAX_VIDEO_DURATION_SEC) {
           reject(`file duration (${video.duration.toString()}s) exceeds allowed maximum (${MAX_VIDEO_DURATION_SEC/60}min)!`);
         }
         resolve();

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -125,9 +125,10 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
     <Layout centered spinningLogo>
       {
         (errorMessage || error)
-          ? <div className="errorMsg"><h1>Oops there was a problem uploading your file!</h1>
-            <p>{(error && 'Error fetching API') || errorMessage}</p>
-            <Button onClick={resetPage}>Start over</Button>
+          ? <div>
+              <h1>Oops there was a problem uploading your file!</h1>
+              <p>{(error && 'Error fetching API') || errorMessage}</p>
+              <Button onClick={resetPage}>Start over</Button>
             </div>
           : <div className="percent"><h1>{progress ? `${progress}` : '0'}</h1></div>
       }

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -18,7 +18,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
   const [isPreparing, setIsPreparing] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [inputValidated, setInputValidated] = useState(false);
-  const [validationError, setValidationError] = useState(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const { data, error } = useSwr(
     () => (isPreparing ? `/api/uploads/${uploadId}` : null),
@@ -78,12 +78,12 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
   }, [upload]);
 
 
-  const startFileValidation = (file) => {
+  const startFileValidation = (_file: File) => {
     // Attempt to load the file as a video element and inspect its duration
     // metadata. This is not an authoritative check of video duration, but
     // rather intended to serve as just a simple and fast sanity check.
-    if (!file.type.includes("video")) {
-      console.warn(`file type (${file.type}) does not look like video!`);
+    if (!_file.type.includes("video")) {
+      console.warn(`file type (${_file.type}) does not look like video!`);
       setInputValidated(true);
       return;
     }

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -139,7 +139,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
           align-items: center;
         }
 
-        h1 {
+        .percent h1 {
           font-size: 8vw;
         }
       `}

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -5,7 +5,7 @@ import useSwr from 'swr';
 import Layout from './layout';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
-const MAX_VIDEO_DURATION_SEC = 3600
+const MAX_VIDEO_DURATION_SEC = 3600;
 
 type Props = {
   file: File
@@ -83,43 +83,43 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
     // metadata. This is not an authoritative check of video duration, but
     // rather intended to serve as just a simple and fast sanity check.
     if (!file.type.includes("video")) {
-      console.warn(`file type (${file.type}) does not look like video!`)
+      console.warn(`file type (${file.type}) does not look like video!`);
       setInputValidated(true);
-      return
+      return;
     }
 
-    var video = document.createElement('video');
+    const video = document.createElement('video');
     video.preload = 'metadata';
     video.onloadedmetadata = function() {
       URL.revokeObjectURL(video.src);
       if (video.duration > MAX_VIDEO_DURATION_SEC) {
         setValidationError(`file duration (${video.duration.toString()}s) exceeds allowed maximum (${MAX_VIDEO_DURATION_SEC}s)!`);
-        return
+        return;
       }
       setInputValidated(true);
-    }
-    video.onerror = function(e) {
+    };
+    video.onerror = function() {
       // The file has a video MIME type, but we were unable to load its
       // metadata for some reason.
       console.warn("failed to load video file metadata for validation!");
       URL.revokeObjectURL(video.src);
       setInputValidated(true);
-    }
+    };
     video.src = URL.createObjectURL(file);
-  }
+  };
 
   useEffect(() => {
     if (!file) {
-      return
+      return;
     }
 
     if (inputValidated || validationError) {
       if (validationError) {
-        setErrorMessage(validationError)
-        return
+        setErrorMessage(validationError);
+        return;
       }
       startUpload(file);
-      return
+      return;
     }
 
     startFileValidation(file);

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -92,7 +92,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
       video.preload = 'metadata';
       video.onloadedmetadata = function() {
         URL.revokeObjectURL(video.src);
-        if (video.duration > MAX_VIDEO_DURATION_MIN*60) {
+        if (video.duration !== Infinity && video.duration > MAX_VIDEO_DURATION_MIN*60) {
           const dur = Math.round(video.duration * 100) / 100;
           reject(`file duration (${dur.toString()}s) exceeds allowed maximum (${MAX_VIDEO_DURATION_MIN}min)!`);
         }
@@ -117,7 +117,6 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
     startFileValidation(file).then(() => {
       startUpload(file);
     }).catch((error => {
-      console.log(error);
       setErrorMessage(error);
     }));
   }, [file]);

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -6,14 +6,14 @@ import Layout from './layout';
 import Button from './button';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
-const MAX_VIDEO_DURATION_MIN = 1;
+const MAX_VIDEO_DURATION_MIN = 60;
 
 type Props = {
   file: File;
-  setShowUploadPage: (b: boolean) => void;
+  resetPage: () => void;
 };
 
-const UploadProgressFullpage: React.FC<Props> = ({ file, setShowUploadPage }) => {
+const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadId, setUploadId] = useState('');
   const [progress, setProgress] = useState(0);
@@ -128,7 +128,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, setShowUploadPage }) =>
         (errorMessage || error)
           ? <div className="errorMsg"><h1>Oops there was a problem uploading your file!</h1>
             <p>{(error && 'Error fetching API') || errorMessage}</p>
-            <Button onClick={() => setShowUploadPage(false)}>Start over</Button>
+            <Button onClick={resetPage}>Start over</Button>
             </div>
           : <div className="percent"><h1>{progress ? `${progress}` : '0'}</h1></div>
       }

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -4,22 +4,21 @@ import * as UpChunk from '@mux/upchunk';
 import useSwr from 'swr';
 import Layout from './layout';
 import Button from './button';
-import Index from '../pages/index';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
-const MAX_VIDEO_DURATION_MIN = 60;
+const MAX_VIDEO_DURATION_MIN = 1;
 
 type Props = {
-  file: File
+  file: File;
+  setShowUploadPage: (b: boolean) => void;
 };
 
-const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
+const UploadProgressFullpage: React.FC<Props> = ({ file, setShowUploadPage }) => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadId, setUploadId] = useState('');
   const [progress, setProgress] = useState(0);
   const [isPreparing, setIsPreparing] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const [resetIndexPage, setResetIndexPage] = useState(false);
 
   const { data, error } = useSwr(
     () => (isPreparing ? `/api/uploads/${uploadId}` : null),
@@ -107,7 +106,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
         resolve();
       };
       video.src = URL.createObjectURL(file);
-    })
+    });
   };
 
   useEffect(() => {
@@ -123,17 +122,13 @@ const UploadProgressFullpage: React.FC<Props> = ({ file }) => {
     }));
   }, [file]);
 
-  if (resetIndexPage) {
-    return <Index />
-  }
-
   return (
     <Layout centered spinningLogo>
       {
         (errorMessage || error)
           ? <div className="errorMsg"><h1>Oops there was a problem uploading your file!</h1>
             <p>{(error && 'Error fetching API') || errorMessage}</p>
-            <Button onClick={() => setResetIndexPage(true)}>Start over</Button>
+            <Button onClick={() => setShowUploadPage(false)}>Start over</Button>
             </div>
           : <div className="percent"><h1>{progress ? `${progress}` : '0'}</h1></div>
       }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,6 +24,7 @@ const Index: React.FC<Props> = () => {
   const onInputChange = () => {
     if (inputRef.current && inputRef.current.files && inputRef.current.files[0]) {
       setFile(inputRef.current.files[0]);
+      setShowUploadPage(true);
     }
   };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,7 @@ const Index: React.FC<Props> = () => {
   };
 
   if (file && showUploadPage) {
-    return <UploadProgressFullpage file={file} setShowUploadPage={setShowUploadPage}/>;
+    return <UploadProgressFullpage file={file} resetPage={() => setShowUploadPage(false)}/>;
   }
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,11 +9,13 @@ type Props = null;
 
 const Index: React.FC<Props> = () => {
   const [file, setFile] = useState<File | null>(null);
+  const [showUploadPage, setShowUploadPage] = useState(true);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const onDrop = useCallback((acceptedFiles) => {
     if (acceptedFiles && acceptedFiles[0]) {
       setFile(acceptedFiles[0]);
+      setShowUploadPage(true);
     } else {
       console.warn('got a drop event but no file'); // eslint-disable-line no-console
     }
@@ -25,8 +27,8 @@ const Index: React.FC<Props> = () => {
     }
   };
 
-  if (file) {
-    return <UploadProgressFullpage file={file} />;
+  if (file && showUploadPage) {
+    return <UploadProgressFullpage file={file} setShowUploadPage={setShowUploadPage}/>;
   }
 
   return (


### PR DESCRIPTION
Attempt to guess the input video file's duration by creating a video element and inspecting its metadata. If the video an unexpected type or we fail to load the blob's metadata, we attempt to upload the file normally.