### PR TITLE
Add the ability to link directly to a time

### DIFF
--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -111,10 +111,6 @@ const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, p
         );
       }
 
-      if (currentTime) {
-        video.currentTime = currentTime;
-      }
-
       if (typeof mux !== 'undefined' && process.env.NEXT_PUBLIC_MUX_ENV_KEY) {
         mux.monitor(video, {
           hlsjs: hls,
@@ -141,6 +137,13 @@ const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, p
       }
     };
   }, [playbackId, videoRef]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (currentTime && video) {
+      video.currentTime = currentTime;
+    }
+  }, [currentTime])
 
   return (
     <>

--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -33,6 +33,7 @@ import { useCombinedRefs } from '../util/use-combined-refs';
 type Props = {
   playbackId: string
   poster: string
+  currentTime?: number
   onLoaded: () => void
   onError: (error: ErrorEvent) => void
 };
@@ -44,7 +45,7 @@ type SizedEvent = {
   }
 };
 
-const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, poster, onLoaded, onError }, ref) => {
+const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, poster, currentTime, onLoaded, onError }, ref) => {
   const videoRef = useRef<HTMLVideoElementWithPlyr>(null);
   const metaRef = useCombinedRefs(ref, videoRef);
   const playerRef = useRef<Plyr | null>(null);
@@ -109,6 +110,11 @@ const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, p
           'This is an old browser that does not support MSE https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API',
         );
       }
+
+      if (currentTime) {
+        video.currentTime = currentTime;
+      }
+
       if (typeof mux !== 'undefined' && process.env.NEXT_PUBLIC_MUX_ENV_KEY) {
         mux.monitor(video, {
           hlsjs: hls,
@@ -168,9 +174,9 @@ const VideoPlayer = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, p
           cursor: pointer;
         }
         @media only screen and (min-width: ${breakpoints.md}px) {
-          video {           
+          video {
             width: ${isVertical ? 'auto' : '1000px'};
-            height: ${isVertical ? '600px' : 'auto'}; 
+            height: ${isVertical ? '600px' : 'auto'};
             max-height: 70vh;
             min-width: 30rem;
           }

--- a/pages/v/[id]/embed.tsx
+++ b/pages/v/[id]/embed.tsx
@@ -111,12 +111,14 @@ const PlaybackEmbedded: React.FC<Props> = ({ playbackId, poster }) => {
 
   const showLoading = (!isLoaded && !errorMessage);
 
+  const startTime = router.query?.time && parseFloat(router.query.time as string) || 0;
+
   return (
     <>
       {errorMessage && <h1 className="error-message">{errorMessage}</h1>}
       {showLoading && <FullpageLoader text="Loading player" />}
       <div className="wrapper">
-        <VideoPlayer ref={videoRef} playbackId={playbackId} poster={poster} onLoaded={() => setIsLoaded(true)} onError={onError} />
+        <VideoPlayer ref={videoRef} playbackId={playbackId} poster={poster} currentTime={startTime} onLoaded={() => setIsLoaded(true)} onError={onError} />
         <div className='asterisk-container'>
           <AsteriskButton onOpenOverlay={onOpenOverlay} />
         </div>

--- a/pages/v/[id]/index.tsx
+++ b/pages/v/[id]/index.tsx
@@ -86,6 +86,8 @@ const Playback: React.FC<Props> = ({ playbackId, shareUrl, poster }) => {
     }, 5000);
   };
 
+  const startTime = router.query?.time && parseFloat(router.query.time as string) || 0;
+
   return (
     <Layout
       metaTitle={META_TITLE}
@@ -96,7 +98,7 @@ const Playback: React.FC<Props> = ({ playbackId, shareUrl, poster }) => {
       {errorMessage && <h1 className="error-message">{errorMessage}</h1>}
       {showLoading && <FullpageLoader text="Loading player" />}
       <div className="wrapper">
-        {!openReport && <VideoPlayer playbackId={playbackId} poster={poster} onLoaded={() => setIsLoaded(true)} onError={onError} />}
+        {!openReport && <VideoPlayer playbackId={playbackId} poster={poster} currentTime={startTime} onLoaded={() => setIsLoaded(true)} onError={onError} />}
         <div className="actions">
           {!openReport && <a onClick={copyUrl} onKeyPress={copyUrl} role="button" tabIndex={0}>{ isCopied ? 'Copied to clipboard' :'Copy video URL' }</a>}
           {!openReport && (


### PR DESCRIPTION
If you include the `time` query param in a link, it will link directly to that timestamp in the video. Useful for linking directly to chapters, etc.