### PR TITLE
Force `normalize-url` to version 4.5.1 for Snyk ReDos warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "next-secure-headers": "^2.0.0",
     "nock": "^13.0.11",
     "typescript": "^4.0.2"
+  },
+  "resolutions": {
+    "normalize-url": "^4.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,10 +5071,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+normalize-url@^4.1.0, normalize-url@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
See https://app.snyk.io/org/muxinc/project/3570d762-99ed-42e1-8006-5e21b264b4ad#issue-SNYK-JS-NORMALIZEURL-1296539
for more details.

Resolves SC#7792