### PR TITLE
fix #64 add camera support for safari

### DIFF
--- a/components/record-page.tsx
+++ b/components/record-page.tsx
@@ -296,7 +296,8 @@ const RecordPage: React.FC<NoProps> = () => {
     try {
       setStartRecordTime((new Date()).valueOf());
       const preferredOptions = { mimeType: 'video/webm;codecs=vp9' };
-      const backupOptions = { mimeType: 'video/mp4' };
+      const backupOptions = { mimeType: 'video/webm;codecs=vp8,opus' };
+      const lastResortOptions = { mimeType: 'video/mp4;codecs=avc1' };
       let options = preferredOptions;
       /*
        * MediaRecorder.isTypeSupported is not a thing in safari,
@@ -305,6 +306,9 @@ const RecordPage: React.FC<NoProps> = () => {
       if (typeof MediaRecorder.isTypeSupported === 'function') {
         if (!MediaRecorder.isTypeSupported(preferredOptions.mimeType)) {
           options = backupOptions;
+          if (!MediaRecorder.isTypeSupported(options.mimeType)) {
+            options = lastResortOptions;
+          }
         }
       }
 
@@ -333,7 +337,7 @@ const RecordPage: React.FC<NoProps> = () => {
       return;
     }
     recorderRef.current.onstop = function onRecorderStop () {
-      finalBlob.current = new Blob(mediaChunks.current, { type: 'video/webm' });
+      finalBlob.current = new Blob(mediaChunks.current, { type: recorderRef.current?.mimeType });
       const objUrl = URL.createObjectURL(finalBlob.current);
       if (videoRef.current !== null) {
         videoRef.current.srcObject = null;

--- a/components/record-page.tsx
+++ b/components/record-page.tsx
@@ -296,7 +296,7 @@ const RecordPage: React.FC<NoProps> = () => {
     try {
       setStartRecordTime((new Date()).valueOf());
       const preferredOptions = { mimeType: 'video/webm;codecs=vp9' };
-      const backupOptions = { mimeType: 'video/webm;codecs=vp8,opus' };
+      const backupOptions = { mimeType: 'video/mp4' };
       let options = preferredOptions;
       /*
        * MediaRecorder.isTypeSupported is not a thing in safari,

--- a/components/video-player.tsx
+++ b/components/video-player.tsx
@@ -6,7 +6,7 @@ import Hls from 'hls.js';
 import mux from 'mux-embed';
 
 import logger from '../lib/logger';
-import { getStreamBaseUrl, getImageBaseUrl } from '../lib/urlutils'
+import { getStreamBaseUrl, getImageBaseUrl } from '../lib/urlutils';
 import { breakpoints } from '../style-vars';
 import { HTMLVideoElementWithPlyr } from '../types';
 import { useCombinedRefs } from '../util/use-combined-refs';

--- a/lib/slack-notifier.ts
+++ b/lib/slack-notifier.ts
@@ -1,7 +1,7 @@
 import got from './got-client';
 import { HOST_URL } from '../constants';
 import { ModerationScores } from '../types';
-import { getImageBaseUrl } from './urlutils'
+import { getImageBaseUrl } from './urlutils';
 
 const slackWebhook = process.env.SLACK_WEBHOOK_ASSET_READY;
 const moderatorPassword = process.env.SLACK_MODERATOR_PASSWORD;

--- a/lib/urlutils.ts
+++ b/lib/urlutils.ts
@@ -1,4 +1,4 @@
-const deliveryDomain = process.env.NEXT_PUBLIC_MUX_BYO_DOMAIN || "mux.com"
+const deliveryDomain = process.env.NEXT_PUBLIC_MUX_BYO_DOMAIN || "mux.com";
 
 export function getStreamBaseUrl() {
   return `https://stream.${deliveryDomain}`;

--- a/pages/v/[id]/embed.tsx
+++ b/pages/v/[id]/embed.tsx
@@ -9,7 +9,7 @@ import Asterisk from '../../../components/asterisk';
 import { OPEN_SOURCE_URL, MUX_HOME_PAGE_URL, HOST_URL } from '../../../constants';
 import { HTMLVideoElementWithPlyr } from '../../../types';
 import logger from '../../../lib/logger';
-import { getImageBaseUrl } from '../../../lib/urlutils'
+import { getImageBaseUrl } from '../../../lib/urlutils';
 
 type Params = {
   id: string;


### PR DESCRIPTION
Starting a recording with a camera in Safari causes a failure, error messages show both on the page and in the console. Users cannot record and submit videos with the camera in Safari.