### PR TITLE
Try a 30 megabyte upload chunk size

### DIFF
--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -53,6 +53,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
     setIsUploading(true);
     try {
       const upChunk = UpChunk.createUpload({
+        chunkSize: 31457280, // 30MB
         endpoint: createUpload,
         maxFileSize: 2**20, // 1GB
         file: _file,

--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -53,7 +53,7 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
     setIsUploading(true);
     try {
       const upChunk = UpChunk.createUpload({
-        chunkSize: 31457280, // 30MB
+        chunkSize: 30720, // 30MB
         endpoint: createUpload,
         maxFileSize: 2**20, // 1GB
         file: _file,


### PR DESCRIPTION
This significantly improves performance on faster connections, with the possible downside of having to retry a larger segment if a conn is dropped partway through a segment.

I would like to leave this in a PR so we can have a side-by-side preview app to test tomorrow.