### PR TITLE
improv/metadata consistent between MuxPlayer & Plyr

### DIFF
--- a/components/mux-player.tsx
+++ b/components/mux-player.tsx
@@ -15,7 +15,18 @@ const MuxPlayerInternal: React.FC<Props> = ({ playbackId, poster, currentTime, o
   }, []);
 
   return (
-    <MuxPlayer playbackId={playbackId} poster={poster} startTime={currentTime} envKey={process.env.NEXT_PUBLIC_MUX_ENV_KEY} streamType="on-demand" />
+    <MuxPlayer
+      playbackId={playbackId}
+      poster={poster}
+      startTime={currentTime}
+      envKey={process.env.NEXT_PUBLIC_MUX_ENV_KEY}
+      streamType="on-demand"
+      metadata={{
+        video_id: playbackId,
+        video_title: playbackId,
+        video_stream_type: 'on-demand',
+      }}
+    />
   );
 };
 

--- a/components/plyr-player.tsx
+++ b/components/plyr-player.tsx
@@ -73,7 +73,6 @@ const PlyrPlayer: React.FC<Props> = ({ playbackId, poster, currentTime, onLoaded
           Hls,
           data: {
             env_key: process.env.NEXT_PUBLIC_MUX_ENV_KEY,
-
             player_name: 'hls.js player v1',
             video_id: playbackId,
             video_title: playbackId,


### PR DESCRIPTION
Pass in the same Mux Data Metadata for MuxPlayer that we have for Plyr