### PR TITLE
Add URL upload functionality to stream.new indexpage  - copy of aa/delete-this-later

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@google-cloud/vision": "^2.3.2",
     "@mux-elements/mux-player-react": "^0.1.0-alpha.7",
     "@mux-elements/mux-video-react": "^0.2.6",
-    "@mux/mux-node": "^3.2",
+    "@mux/mux-node": "^5.0.0-rc.1",
     "@mux/upchunk": "^2.3",
     "@types/probe-image-size": "^7.0.0",
     "copy-to-clipboard": "^3.3.1",

--- a/pages/api/assets/index.ts
+++ b/pages/api/assets/index.ts
@@ -10,6 +10,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
     case 'POST':
       try {
         const asset = await Video.Assets.create({
+          // this is the text box contents from index.ts
           input: req.body,
           "playback_policy": [
             "public"
@@ -22,7 +23,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
       } catch (e) {
         res.statusCode = 500;
         console.error('Request error', e); // eslint-disable-line no-console
-        res.json({ error: 'Error creating upload' });
+        res.json({ error: 'Error creating asset' });
       }
       break;
     default:

--- a/pages/api/assets/index.ts
+++ b/pages/api/assets/index.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import Mux from '@mux/mux-node';
+
+const { Video } = new Mux();
+
+export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  const { method, body } = req;
+
+  switch (method) {
+    case 'POST':
+      try {
+        const asset = await Video.Assets.create({
+          input: req.body,
+          "playback_policy": [
+            "public"
+          ],
+        });
+        res.json({
+          id: asset.id,
+          status: asset.status,
+        });
+      } catch (e) {
+        res.statusCode = 500;
+        console.error('Request error', e); // eslint-disable-line no-console
+        res.json({ error: 'Error creating upload' });
+      }
+      break;
+    default:
+      res.setHeader('Allow', ['POST']);
+      res.status(405).end(`Method ${method} Not Allowed`);
+  }
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -55,6 +55,9 @@ const Index: React.FC<Props> = () => {
           body: myEndpoint.current.value
         })
           .then((res) => res.json())
+          // this needs to change because
+          // a direct upload isn't happening,
+          // if something different should happen
           .then(({ id, status }) => {
             setAssetId(id);
             return status;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,8 @@ import { breakpoints } from '../style-vars';
 import Layout from '../components/layout';
 import Button from '../components/button';
 import UploadProgressFullpage from '../components/upload-progress-fullpage';
+// import Mux from '@mux/mux-node';
+// const { Video } = new Mux('', '')
 
 type Props = null;
 
@@ -11,6 +13,9 @@ const Index: React.FC<Props> = () => {
   const [file, setFile] = useState<File | null>(null);
   const [showUploadPage, setShowUploadPage] = useState(true);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [assetID, setAssetId] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const myEndpoint = useRef<HTMLInputElement>(null);
 
   const onDrop = useCallback((acceptedFiles) => {
     if (acceptedFiles && acceptedFiles[0]) {
@@ -32,6 +37,54 @@ const Index: React.FC<Props> = () => {
     return <UploadProgressFullpage file={file} resetPage={() => setShowUploadPage(false)}/>;
   }
 
+  // const myFunc1 = async () => {
+  //   const asset = await Video.Assets.create({
+  //     input: myEndpoint,
+  //     "playback_policy": [
+  //       "public"
+  //     ],
+  //   });
+  // }
+
+  const myFunc2 = async () => {
+    if (myEndpoint) {
+
+      try {
+        return fetch('/api/assets', {
+          method: 'POST',
+          body: myEndpoint.current.value
+        })
+          .then((res) => res.json())
+          .then(({ id, status }) => {
+            setAssetId(id);
+            return status;
+          });
+      } catch (e) {
+        console.error('Error in createUpload', e); // eslint-disable-line no-console
+        setErrorMessage('Error creating upload');
+        return Promise.reject(e);
+      }
+
+    }
+    try {
+      return fetch('/api/assets', {
+        method: 'POST',
+      })
+        .then((res) => res.json())
+        .then(({ id, status }) => {
+          setAssetId(id);
+          console.log(id)
+          console.log(status)
+          return status;
+        });
+    } catch (e) {
+      console.error('Error in createUpload', e); // eslint-disable-line no-console
+      setErrorMessage('Error creating upload');
+      return Promise.reject(e);
+    }
+
+  }
+
   return (
     <Layout
       onFileDrop={onDrop}
@@ -40,6 +93,8 @@ const Index: React.FC<Props> = () => {
         <div>
           <h1>Add a video.</h1>
           <h1>Get a shareable link to stream it.</h1>
+          <input className='aminBox' ref={myEndpoint} id="location" type="text" placeholder="Mux Upload URL" /> 
+          <input onClick={myFunc2} className='aminBox' id="startupload" type="button" value="start upload" /> 
         </div>
         <div className="cta">
           <div className="drop-notice">
@@ -61,7 +116,7 @@ const Index: React.FC<Props> = () => {
         </div>
       </div>
       <style jsx>{`
-        input {
+        input:not(.aminBox) {
           display: none;
         }
         .drop-notice {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ const Index: React.FC<Props> = () => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [assetID, setAssetId] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const myEndpoint = useRef<HTMLInputElement>(null);
+  const myEndpoint = useRef<HTMLInputElement | null>(null);
 
   const onDrop = useCallback((acceptedFiles) => {
     if (acceptedFiles && acceptedFiles[0]) {
@@ -35,29 +35,56 @@ const Index: React.FC<Props> = () => {
     return <UploadProgressFullpage file={file} resetPage={() => setShowUploadPage(false)}/>;
   }
 
-  // const myFunc1 = async () => {
-  //   const asset = await Video.Assets.create({
-  //     input: myEndpoint,
-  //     "playback_policy": [
-  //       "public"
-  //     ],
-  //   });
-  // }
+  function isValidHTTPURL(inputString: string | URL) {
+    let url;
+    try {
+      url = new URL(inputString);
+    } catch (_) {
+      return false;
+    }
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
 
   const myFunc2 = async () => {
-    if (myEndpoint) {
+    // console.log(isValidHTTPURL(myEndpoint.current?.value)) // true
+    if (! isValidHTTPURL(myEndpoint.current?.value)) {
+      console.log ('not a valid url, try again ')
+    }
+    else {
+      console.log ('valid url')
 
+      if (myEndpoint && isValidHTTPURL(myEndpoint.current?.value)) {
+        console.log('myEndpoint', myEndpoint, myEndpoint.current.value);
+        try {
+          return fetch('/api/assets', {
+            method: 'POST',
+            body: myEndpoint.current.value // Error: Endpoint is possibly null
+          })
+            .then((res) => res.json())
+            // this needs to change because
+            // a direct upload isn't happening,
+            // if something different should happen
+            .then(({ id, status }) => {
+              setAssetId(id);
+              console.log('new asset id', id);
+              console.log('status', status);
+              return status;
+            });
+        } catch (e) {
+          console.error('Error in createUpload', e); // eslint-disable-line no-console
+          setErrorMessage('Error creating upload');
+          return Promise.reject(e);
+        }
+      }
       try {
         return fetch('/api/assets', {
           method: 'POST',
-          body: myEndpoint.current.value
         })
           .then((res) => res.json())
-          // this needs to change because
-          // a direct upload isn't happening,
-          // if something different should happen
           .then(({ id, status }) => {
             setAssetId(id);
+            console.log('new asset id', id);
+            console.log('status', status)
             return status;
           });
       } catch (e) {
@@ -65,25 +92,7 @@ const Index: React.FC<Props> = () => {
         setErrorMessage('Error creating upload');
         return Promise.reject(e);
       }
-
     }
-    try {
-      return fetch('/api/assets', {
-        method: 'POST',
-      })
-        .then((res) => res.json())
-        .then(({ id, status }) => {
-          setAssetId(id);
-          console.log(id)
-          console.log(status)
-          return status;
-        });
-    } catch (e) {
-      console.error('Error in createUpload', e); // eslint-disable-line no-console
-      setErrorMessage('Error creating upload');
-      return Promise.reject(e);
-    }
-
   }
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,8 +4,6 @@ import { breakpoints } from '../style-vars';
 import Layout from '../components/layout';
 import Button from '../components/button';
 import UploadProgressFullpage from '../components/upload-progress-fullpage';
-// import Mux from '@mux/mux-node';
-// const { Video } = new Mux('', '')
 
 type Props = null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,14 +628,14 @@
     hls.js "1.1.5"
     mux-embed "4.5.0"
 
-"@mux/mux-node@^3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@mux/mux-node/-/mux-node-3.3.2.tgz#ef8986b9b89161265d9e28d1c723eee2ca2cfadf"
-  integrity sha512-lBKRrsVwtUg0Vb9J/fI65M+9bw3Q27vCM5h5RzJc7BNwr7KxkykEdvaJwixflHbaQASosfa/lRROxYSL5L5S1Q==
+"@mux/mux-node@^5.0.0-rc.1":
+  version "5.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@mux/mux-node/-/mux-node-5.0.0-rc.1.tgz#91be34db0a69b689173a1441467ceafaa4d45bc6"
+  integrity sha512-6BTRPDO1iMnjr4JfpDhJgf5tKVTTMMI/mPYiCdfqAQJ3GW4p4znFUtwW+EiHWV60wlaM8jENlOkegQcgoostRQ==
   dependencies:
     axios "^0.25.0"
     esdoc-ecmascript-proposal-plugin "^1.0.0"
-    jsonwebtoken "^8.4.0"
+    jsonwebtoken "^8.5.1"
 
 "@mux/upchunk@^2.3":
   version "2.3.0"
@@ -2606,9 +2606,9 @@ flatted@^3.1.0:
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 follow-redirects@^1.14.7:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3875,7 +3875,7 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-jsonwebtoken@^8.4.0:
+jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==


### PR DESCRIPTION
This branch is a copy of Amin's branch of https://github.com/muxinc/stream.new/tree/aa/delete-this-later and one method from os/add-url-drop-functionality. 

It is @aminamos 's + @liv-yaa 's attempt to solve this open Stream.new Issue https://github.com/muxinc/stream.new/issues/56. Task at hand is:
> "from the index page, if you paste a URL it should just create an asset from that URL"

Current state: 
- you can see uploads of urls are working from the button on the homepage


Next steps:
- Find a way to drag-drop a URL into the ["Dropzone"](https://react-dropzone.js.org/#section-basic-example)
- Have this undergo validation and upload as above

