### PR TITLE
improv:upload telemetry data format (requested by data team)

### DIFF
--- a/components/upload-progress-fullpage.tsx
+++ b/components/upload-progress-fullpage.tsx
@@ -8,16 +8,18 @@ import Button from './button';
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 const MAX_VIDEO_DURATION_MIN = 60;
 
+type ChunkInfo = {
+  size: number;
+  uploadStarted: number;
+  uploadFinished?: number;
+}
+
 type UploadTelemetry = {
   fileSize: number;
   uploadStarted: number;
   uploadFinished?: number;
   chunkSize: number;
-  [chunk: number]: {
-    size: number;
-    uploadStarted: number;
-    uploadFinished?: number;
-  };
+  chunks: ChunkInfo[];
 };
 
 type Props = {
@@ -74,17 +76,18 @@ const UploadProgressFullpage: React.FC<Props> = ({ file, resetPage }) => {
         fileSize: _file.size,
         chunkSize: upChunk.chunkSize,
         uploadStarted: Date.now(),
+        chunks: [],
       };
 
       upChunk.on('attempt', ({ detail }) => {
-        uploadAnalytics[detail.chunkNumber] = {
+        uploadAnalytics.chunks[detail.chunkNumber] = {
           size: detail.chunkSize,
           uploadStarted: Date.now(),
         };
       });
 
       upChunk.on('chunkSuccess', ({ detail }) => {
-        uploadAnalytics[detail.chunk].uploadFinished = Date.now();
+        uploadAnalytics.chunks[detail.chunk].uploadFinished = Date.now();
       });
 
       upChunk.on('error', (err) => {


### PR DESCRIPTION
Previously, `data` had keys for `0`, `1`, `2`, etc. @mpavillet informed me that is basically impossible to query in a meaningful way in our datastore.

It was suggested that `chunks` be an array instead, so we can more easily query things like:
- num of chunks
- avg chunk size
- time to upload each chunk
- etc.

```
{
  type: 'upload',
  data: {
    fileSize: 42634400,
    chunkSize: 30720,
    uploadStarted: 1650666485990,
    chunks: [
      {size: 31457280, uploadStarted: 1650666486741, uploadFinished: 1650666497378 }, 
      {size:11177120, uploadStarted: 1650666497386, uploadFinished: 1650666634532 }
    ],
    uploadFinished: 1650666634532
  },
  uploaderCountry: 'US',
  uploaderCountryRegion: 'CA',
  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36'
}
```