### PR TITLE
Move onstop cb to MediaRecorder setup

### DIFF
--- a/components/record-page.tsx
+++ b/components/record-page.tsx
@@ -320,6 +320,18 @@ const RecordPage: React.FC<NoProps> = () => {
         mediaChunks.current.push(evt.data);
         logger('added media recorder chunk', mediaChunks.current.length);
       };
+      recorderRef.current.onstop = function onRecorderStop () {
+        finalBlob.current = new Blob(mediaChunks.current, { type: recorderRef.current?.mimeType });
+        const objUrl = URL.createObjectURL(finalBlob.current);
+        if (videoRef.current !== null) {
+          videoRef.current.srcObject = null;
+          videoRef.current.src = objUrl;
+          videoRef.current.controls = true;
+          videoRef.current.muted = false;
+          setIsReviewing(true);
+        }
+        cleanup();
+      };
       setRecordState(RecordState.RECORDING);
     } catch (err) {
       logger.error(err); // eslint-disable-line no-console
@@ -331,23 +343,12 @@ const RecordPage: React.FC<NoProps> = () => {
     countdownTimerRef.current?.reset();
     cleanup();
   };
+
   const stopRecording = () => {
     if (!recorderRef.current) {
       logger.warn('cannot stopRecording() without a recorderRef');
       return;
     }
-    recorderRef.current.onstop = function onRecorderStop () {
-      finalBlob.current = new Blob(mediaChunks.current, { type: recorderRef.current?.mimeType });
-      const objUrl = URL.createObjectURL(finalBlob.current);
-      if (videoRef.current !== null) {
-        videoRef.current.srcObject = null;
-        videoRef.current.src = objUrl;
-        videoRef.current.controls = true;
-        videoRef.current.muted = false;
-        setIsReviewing(true);
-      }
-      cleanup();
-    };
     recorderRef.current.stop();
     stopUserMedia();
   };


### PR DESCRIPTION
Report from @mpavillet:

> Currently, if you start recording your screen and then hit “stop sharing” before going back to stream.new, you can’t stop the recording.

Steps to reproduce:
- Go to stream.new
- Click “record my screen”
- Click “Allow browser to screenshare”
- Select a chrome tab to share
- Hit “start recording”
- Record your screen
- From the shared tab, hit “Stop sharing”
- Go to the stream.new tab
- Hit “Stop recording
- It doesn’t stop (see console)

This is due to the `onstop` callback only being configured once the `stopRecording` method is invoked rather than wiring it up on MediaRecorder setup. This PR fixes the issue.