### PR TITLE
Add height to mux-player

### DIFF
--- a/components/mux-player.tsx
+++ b/components/mux-player.tsx
@@ -41,7 +41,7 @@ const MuxPlayerInternal: React.FC<Props> = ({ forwardedRef, playbackId, poster, 
       streamType="on-demand"
       primaryColor={color}
       placeholder={blurHashBase64}
-      style={{ aspectRatio: `${aspectRatio}`, maxWidth: '100%', maxHeight: '100%', width: 'auto', display: 'block', marginLeft: 'auto', marginRight: 'auto' }}
+      style={{ aspectRatio: `${aspectRatio}`, maxWidth: '100%', maxHeight: '100%', width: 'auto', display: 'block', marginLeft: 'auto', marginRight: 'auto', height: '100%' }}
       preferPlayback={preferMse ? 'mse' : 'native'}
       metadata={{
         video_id: playbackId,


### PR DESCRIPTION
- Fixes safari 16.4 video container overflow
- Smoke tested in Arc, Firefox, Chrome, Safari, + Chrome and Safari on iOS
- Props to @luwes for the fix