### PR TITLE
let mux player infer stream type

### DIFF
--- a/components/mux-player.tsx
+++ b/components/mux-player.tsx
@@ -51,7 +51,6 @@ const MuxPlayerInternal: React.FC<Props> = ({
         poster={poster}
         startTime={currentTime}
         envKey={process.env.NEXT_PUBLIC_MUX_ENV_KEY}
-        streamType="on-demand"
         accentColor={color}
         placeholder={blurHashBase64}
         style={{


### PR DESCRIPTION
- MuxPlayer can infer the stream type now, so we don't need to explicitly pass it in. This is handy because now we can use stream.new/v/{PLAYBACK_ID} for a live stream