### PR TITLE
feat: Set outputLanguageCode to `en` when requesting summarization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mux/ai": "^0.8.2",
+        "@mux/ai": "^0.9.0",
         "@mux/blurup": "^1.0.2",
         "@mux/mux-node": "^12.8.1",
         "@mux/mux-player-react": "^3.11.4",
@@ -2670,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/@mux/ai": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@mux/ai/-/ai-0.8.2.tgz",
-      "integrity": "sha512-XnJhvrMX8R30+JqqF9VcDhB0LLMvKh63Ya4rEl9Wa/HdtFAbDGbHaB1dOHQLMEUbKJUCIFFAijU4ku8DJRqTtg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@mux/ai/-/ai-0.9.0.tgz",
+      "integrity": "sha512-Qc60gpImmrcKoT1Bnln/8SglgbeCyAl9RinX5MluRbzpGKYFnvn56bYmtxaQ+PoUjF4xvwOrPbo5el1ZIF4fiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@mux/ai": "^0.8.2",
+    "@mux/ai": "^0.9.0",
     "@mux/blurup": "^1.0.2",
     "@mux/mux-node": "^12.8.1",
     "@mux/mux-player-react": "^3.11.4",

--- a/workflows/process-mux-ai.ts
+++ b/workflows/process-mux-ai.ts
@@ -217,6 +217,7 @@ export async function moderateAndSummarize(assetId: string) {
       provider: 'openai',
       tone: 'neutral',
       includeTranscript,
+      outputLanguageCode: 'en',
     }),
     askQuestions(assetId, [
       { question: "Is this a professionally produced full length movie or TV show, or a standalone segment from it?" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: upgrades `@mux/ai` and changes summarization request parameters, which may alter AI output behavior and rely on updated SDK semantics.
> 
> **Overview**
> Forces Mux AI summarization (`getSummaryAndTags`) to return English output by passing `outputLanguageCode: 'en'` in `process-mux-ai.ts`.
> 
> Bumps the `@mux/ai` dependency from `0.8.2` to `0.9.0` (and updates the lockfile) to pick up the corresponding SDK support/changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483c7712ebfa29870303d52950ebd828e6f17a55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->