### PR TITLE
fix: Change button to link to fix delete workflow

### DIFF
--- a/lib/slack-notifier.ts
+++ b/lib/slack-notifier.ts
@@ -24,25 +24,6 @@ type BlockItem = {
     type: string,
     text: string,
   }>,
-  accessory?: {
-    type: string,
-    text: {
-      type: string,
-      text: string,
-    },
-    url: string,
-    style: string
-  },
-  elements?: [{
-    type: string,
-    text: {
-      type: string,
-      emoji: boolean,
-      text: string
-    },
-    style: string,
-    url: string,
-  }]
 };
 
 const baseBlocks = ({ playbackId, assetId, duration }: {playbackId: string, assetId: string, duration: number}): BlockItem[] => ([
@@ -74,19 +55,11 @@ const baseBlocks = ({ playbackId, assetId, duration }: {playbackId: string, asse
     alt_text: 'storyboard',
   },
   {
-    type: 'actions',
-    elements: [
-      {
-        type: 'button',
-        text: {
-          type: 'plain_text',
-          emoji: true,
-          text: 'View on stream.new',
-        },
-        style: 'primary',
-        url: `${HOST_URL}/v/${playbackId}`,
-      },
-    ],
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `<${HOST_URL}/v/${playbackId}|View on stream.new>`,
+    },
   }]);
 
 const deleteButtonBlock = (assetId: string): BlockItem => ({
@@ -217,21 +190,13 @@ export const sendSlackSummarizationResult = async ({
     });
   }
 
-  // Add view button
+  // Add view link
   blocks.push({
-    type: 'actions',
-    elements: [
-      {
-        type: 'button',
-        text: {
-          type: 'plain_text',
-          emoji: true,
-          text: 'View on stream.new',
-        },
-        style: 'primary',
-        url: `${HOST_URL}/v/${playbackId}`,
-      },
-    ],
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `<${HOST_URL}/v/${playbackId}|View on stream.new>`,
+    },
   });
 
   // Always include delete button

--- a/lib/slack-notifier.ts
+++ b/lib/slack-notifier.ts
@@ -93,16 +93,7 @@ const deleteButtonBlock = (assetId: string): BlockItem => ({
   type: 'section',
   text: {
     type: 'mrkdwn',
-    text: 'If this is bad, it can be deleted with 1 click:',
-  },
-  accessory: {
-    type: 'button',
-    text: {
-      type: 'plain_text',
-      text: 'DELETE',
-    },
-    url: `${HOST_URL}/moderator/delete-asset?asset_id=${assetId}&slack_moderator_password=${moderatorPassword}`,
-    style: 'danger',
+    text: `If this is bad, it can be <${HOST_URL}/moderator/delete-asset?asset_id=${assetId}&slack_moderator_password=${moderatorPassword}|deleted with 1 click>.`,
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Notification-only Block Kit shape change in `slack-notifier.ts`; URLs and delete flow endpoints are unchanged.
> 
> **Overview**
> **Fixes Slack moderation notifications** by dropping interactive `actions` / button blocks in favor of **mrkdwn hyperlinks** in `section` blocks, so “View on stream.new” and one-click delete behave correctly when opened from Slack.
> 
> The same link pattern is applied in `baseBlocks`, the summarization “view” footer, and `deleteButtonBlock` (delete URL and moderator password query params are unchanged). **`BlockItem`** is trimmed to remove `accessory` and `elements` types that only supported buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4023f16574a6977ec65fecfffa3726d968b53238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->