### PR TITLE
feat: Update content moderation rules

### DIFF
--- a/lib/moderation-action.spec.ts
+++ b/lib/moderation-action.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import nock from 'nock';
-import { checkAndAutoDelete, checkAndAutoDeleteWatchParty } from './moderation-action';
+import { checkAndAutoDelete, checkAndAutoDeleteQuestion } from './moderation-action';
 import type { ModerateJobOutputs } from '@mux/mux-node/resources/robots-preview/jobs/moderate';
 
 const assetId = 'test-asset-123';
@@ -112,9 +112,11 @@ test('still returns true if Airtable recording fails', async () => {
   // Airtable error should be logged but not prevent deletion
 });
 
-// Watch party moderation tests
+// Question-based moderation tests
 
-test('watch party: deletes when answer is yes and confidence > 0.8', async () => {
+const question = 'Is this a professionally produced full length movie or TV show, or a standalone segment from it?';
+
+test('question: deletes when answer is yes and confidence > 0.8', async () => {
   process.env.AUTO_DELETE_ENABLED = '1';
 
   const scopeMux = nock('https://api.mux.com')
@@ -125,9 +127,10 @@ test('watch party: deletes when answer is yes and confidence > 0.8', async () =>
     .post('/v0/test-base-id/Auto%20Deleted')
     .reply(200, { records: [] });
 
-  const didDelete = await checkAndAutoDeleteWatchParty({
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'yes',
     confidence: 0.85,
   });
@@ -137,12 +140,13 @@ test('watch party: deletes when answer is yes and confidence > 0.8', async () =>
   expect(scopeAirtable.isDone()).toBe(true);
 });
 
-test('watch party: does not delete when confidence is exactly 0.8', async () => {
+test('question: does not delete when confidence is exactly 0.8', async () => {
   process.env.AUTO_DELETE_ENABLED = '1';
 
-  const didDelete = await checkAndAutoDeleteWatchParty({
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'yes',
     confidence: 0.8,
   });
@@ -150,12 +154,13 @@ test('watch party: does not delete when confidence is exactly 0.8', async () => 
   expect(didDelete).toBe(false);
 });
 
-test('watch party: does not delete when confidence <= 0.8', async () => {
+test('question: does not delete when confidence <= 0.8', async () => {
   process.env.AUTO_DELETE_ENABLED = '1';
 
-  const didDelete = await checkAndAutoDeleteWatchParty({
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'yes',
     confidence: 0.75,
   });
@@ -163,12 +168,13 @@ test('watch party: does not delete when confidence <= 0.8', async () => {
   expect(didDelete).toBe(false);
 });
 
-test('watch party: does not delete when answer is no', async () => {
+test('question: does not delete when answer is no', async () => {
   process.env.AUTO_DELETE_ENABLED = '1';
 
-  const didDelete = await checkAndAutoDeleteWatchParty({
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'no',
     confidence: 0.95,
   });
@@ -176,10 +182,11 @@ test('watch party: does not delete when answer is no', async () => {
   expect(didDelete).toBe(false);
 });
 
-test('watch party: does not delete when AUTO_DELETE_ENABLED is not set', async () => {
-  const didDelete = await checkAndAutoDeleteWatchParty({
+test('question: does not delete when AUTO_DELETE_ENABLED is not set', async () => {
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'yes',
     confidence: 0.95,
   });
@@ -187,7 +194,7 @@ test('watch party: does not delete when AUTO_DELETE_ENABLED is not set', async (
   expect(didDelete).toBe(false);
 });
 
-test('watch party: still returns true if Airtable recording fails', async () => {
+test('question: still returns true if Airtable recording fails', async () => {
   process.env.AUTO_DELETE_ENABLED = '1';
 
   const scopeMux = nock('https://api.mux.com')
@@ -198,9 +205,10 @@ test('watch party: still returns true if Airtable recording fails', async () => 
     .post('/v0/test-base-id/Auto%20Deleted')
     .reply(500, { error: 'Internal error' });
 
-  const didDelete = await checkAndAutoDeleteWatchParty({
+  const didDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
+    question,
     answer: 'yes',
     confidence: 0.9,
   });

--- a/lib/moderation-action.ts
+++ b/lib/moderation-action.ts
@@ -27,7 +27,7 @@ async function saveDeletionRecordInAirtable ({ assetId, notes }: { assetId: stri
   }
 }
 
-export async function checkAndAutoDeleteWatchParty({ assetId, playbackId, answer, confidence }: { assetId: string, playbackId: string, answer: string, confidence: number }): Promise<boolean> {
+export async function checkAndAutoDeleteQuestion({ assetId, playbackId, question, answer, confidence }: { assetId: string, playbackId: string, question: string, answer: string, confidence: number }): Promise<boolean> {
   const autoDeleteEnabled = process.env.AUTO_DELETE_ENABLED === '1';
   const shouldDelete = answer === 'yes' && confidence > 0.8;
 
@@ -36,7 +36,7 @@ export async function checkAndAutoDeleteWatchParty({ assetId, playbackId, answer
 
     await saveDeletionRecordInAirtable({
       assetId,
-      notes: `Flagged by: AI watch-party detection — Answer: ${answer}, Confidence: ${confidence.toFixed(3)}`
+      notes: `Flagged by: AI Question — "${question}" — Answer: ${answer}, Confidence: ${confidence.toFixed(3)}`
     });
 
     return true;

--- a/lib/moderation-action.ts
+++ b/lib/moderation-action.ts
@@ -27,7 +27,7 @@ async function saveDeletionRecordInAirtable ({ assetId, notes }: { assetId: stri
   }
 }
 
-export async function checkAndAutoDeleteQuestion({ assetId, playbackId, question, answer, confidence }: { assetId: string, playbackId: string, question: string, answer: string, confidence: number }): Promise<boolean> {
+export async function checkAndAutoDeleteQuestion({ assetId, playbackId, question, answer, confidence }: { assetId: string, playbackId: string, question: string, answer: string | null, confidence: number }): Promise<boolean> {
   const autoDeleteEnabled = process.env.AUTO_DELETE_ENABLED === '1';
   const shouldDelete = answer === 'yes' && confidence > 0.8;
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/workflows/process-mux-ai.ts
+++ b/workflows/process-mux-ai.ts
@@ -4,7 +4,7 @@ import type { ModerateJob, ModerateJobOutputs } from '@mux/mux-node/resources/ro
 import type { SummarizeJob, SummarizeJobOutputs } from '@mux/mux-node/resources/robots-preview/jobs/summarize';
 import type { AskQuestionsJob, AskQuestionsJobOutputs } from '@mux/mux-node/resources/robots-preview/jobs/ask-questions';
 import { sendSlackModerationResult, sendSlackSummarizationResult, sendSlackAutoDeleteMessage } from '../lib/slack-notifier';
-import { checkAndAutoDelete, checkAndAutoDeleteWatchParty } from '../lib/moderation-action';
+import { checkAndAutoDelete, checkAndAutoDeleteQuestion } from '../lib/moderation-action';
 import type { RobotsJobHookPayload, CaptionHookPayload, CaptionStatus } from '../types';
 
 const mux = new Mux();
@@ -170,20 +170,23 @@ async function notifySlackSummarization(
   });
 }
 
+const FULL_LENGTH_CONTENT_QUESTION = "Is this a professionally produced full length movie or TV show, or a standalone segment from it?";
 const WATCH_PARTY_QUESTION = "Is this a watchalong-style video where a person or small group is actively watching and reacting to a full-length movie or TV episode as the main focus of the clip?";
-const WATCH_PARTY_CONFIDENCE_THRESHOLD = 0.8;
 
-async function handleWatchPartyModeration(
+const AUTO_DELETE_QUESTIONS = [FULL_LENGTH_CONTENT_QUESTION, WATCH_PARTY_QUESTION];
+const AUTO_DELETE_CONFIDENCE_THRESHOLD = 0.8;
+
+async function handleQuestionModeration(
   assetId: string,
   questionsResult: AskQuestionsJobOutputs
 ): Promise<boolean> {
   "use step";
 
-  const watchPartyAnswer = questionsResult.answers.find(
-    (qa) => qa.question === WATCH_PARTY_QUESTION
+  const flaggedAnswer = questionsResult.answers.find(
+    (qa) => AUTO_DELETE_QUESTIONS.includes(qa.question) && qa.answer === 'yes' && qa.confidence > AUTO_DELETE_CONFIDENCE_THRESHOLD
   );
 
-  if (!watchPartyAnswer || watchPartyAnswer.answer !== 'yes' || watchPartyAnswer.confidence <= WATCH_PARTY_CONFIDENCE_THRESHOLD) {
+  if (!flaggedAnswer) {
     return false;
   }
 
@@ -191,14 +194,15 @@ async function handleWatchPartyModeration(
   const playbackId = asset.playback_ids?.[0]?.id;
 
   if (!playbackId) {
-    throw new Error(`No playback ID found for asset ${assetId}. Cannot proceed with watch party moderation.`);
+    throw new Error(`No playback ID found for asset ${assetId}. Cannot proceed with question moderation.`);
   }
 
-  const didAutoDelete = await checkAndAutoDeleteWatchParty({
+  const didAutoDelete = await checkAndAutoDeleteQuestion({
     assetId,
     playbackId,
-    answer: watchPartyAnswer.answer,
-    confidence: watchPartyAnswer.confidence,
+    question: flaggedAnswer.question,
+    answer: flaggedAnswer.answer,
+    confidence: flaggedAnswer.confidence,
   });
 
   if (didAutoDelete) {
@@ -206,7 +210,7 @@ async function handleWatchPartyModeration(
     await sendSlackAutoDeleteMessage({
       assetId,
       duration,
-      moderationDetails: `Flagged by: AI Question — "${WATCH_PARTY_QUESTION}" — Answer: ${watchPartyAnswer.answer}, Confidence: ${watchPartyAnswer.confidence.toFixed(3)} | Reasoning: ${watchPartyAnswer.reasoning}`,
+      moderationDetails: `Flagged by: AI Question — "${flaggedAnswer.question}" — Answer: ${flaggedAnswer.answer}, Confidence: ${flaggedAnswer.confidence.toFixed(3)} | Reasoning: ${flaggedAnswer.reasoning}`,
     });
   }
 
@@ -287,7 +291,7 @@ export async function moderateAndSummarize(assetId: string) {
 
   const summarizeJobId = await startSummarizeJob(assetId);
   const questionsJobId = await startAskQuestionsJob(assetId, [
-    { question: "Is this a professionally produced full length movie or TV show, or a standalone segment from it?" },
+    { question: FULL_LENGTH_CONTENT_QUESTION },
     { question: "Is this professionally produced footage of a cycling race?" },
     { question: WATCH_PARTY_QUESTION },
     { question: "Does this video use offensive language, and/or is likely to offend?" },
@@ -334,10 +338,10 @@ export async function moderateAndSummarize(assetId: string) {
   console.log('AI Summarization Result:', JSON.stringify(summaryResult, null, 2)); // eslint-disable-line no-console
   console.log('AI Ask Questions Result:', JSON.stringify(questionsResult, null, 2)); // eslint-disable-line no-console
 
-  // 5. Check for watch party content and auto-delete if flagged.
-  const watchPartyDeleted = await handleWatchPartyModeration(assetId, questionsResult);
+  // 5. Check auto-delete questions and delete if any are flagged.
+  const questionDeleted = await handleQuestionModeration(assetId, questionsResult);
 
-  if (!watchPartyDeleted) {
+  if (!questionDeleted) {
     await notifySlackSummarization(assetId, summaryResult, questionsResult);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Broadens automatic playback deletion beyond watch-party-only rules; misclassification or threshold edge cases could remove legitimate assets when `AUTO_DELETE_ENABLED=1`.
> 
> **Overview**
> **Expands AI-driven auto-delete** from watch-party detection only to any configured ask-questions prompt that returns **yes** with confidence **> 0.8**.
> 
> `checkAndAutoDeleteWatchParty` is renamed to **`checkAndAutoDeleteQuestion`**, which records the specific **question** text in Airtable/Slack instead of a fixed “watch-party” label. The Mux AI workflow now evaluates **`AUTO_DELETE_QUESTIONS`**: full-length professionally produced movie/TV (or segment) **and** the existing watchalong question; the first matching flagged answer triggers deletion and skips the normal summarization Slack notification.
> 
> Tests are updated to cover the generalized question-based helper. **`next-env.d.ts`** only changes the generated routes import path (`dev/types` → `types`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a8bcd5c76ddb2d6788641a36ad07f7560fdae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->